### PR TITLE
feat: In sentence inline bundles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ tmp
 debian-build/
 *.deb
 **/__pycache__/**
+local/**

--- a/docs/examples/live_bundle_example.txt
+++ b/docs/examples/live_bundle_example.txt
@@ -13,6 +13,15 @@ We can also include specific sections of files using line references:
 This makes it easy to create composite documents that include content from
 multiple sources with your own commentary and transitions between sections.
 
+# Inline File Inclusion
+
+Live bundles also support inline file inclusion using the @[file path] syntax.
+For example, this sentence includes @[../live_bundles.txt:L5-5] as an inline quote.
+
+With this syntax, the file content is inserted inline with all line breaks removed.
+This is useful for including short snippets of text within a paragraph without
+disrupting the flow of the document.
+
 # Conclusion
 
 Live bundles are a powerful way to create dynamic documents that combine

--- a/docs/live_bundles.txt
+++ b/docs/live_bundles.txt
@@ -48,6 +48,35 @@ Conclusion
 Each line that contains only a valid file path will be replaced with the content
 of that file. All other lines will be preserved as-is.
 
+Inline File Inclusion
+-------------------
+
+Live bundles also support inline file inclusion using the @[file path] syntax:
+
+```
+This paragraph includes @[/path/to/quote.txt] right in the middle of the text.
+```
+
+With this syntax, the file content is inserted inline with all line breaks removed.
+This is useful for including short snippets of text within a paragraph without
+disrupting the flow of the document.
+
+For example, if quote.txt contains:
+```
+To be or not to be
+That is the question
+```
+
+The result will be:
+```
+This paragraph includes To be or not to be That is the question right in the middle of the text.
+```
+
+You can include multiple inline file references in a single line:
+```
+As @[author.txt] once said: "@[quote.txt]"
+```
+
 Using Line References
 -------------------
 
@@ -65,6 +94,11 @@ Middle section
 Conclusion
 ```
 
+Line references can also be used with inline file inclusion:
+```
+The most important part is @[document.txt:L42-45]
+```
+
 Example Use Cases
 ---------------
 
@@ -72,6 +106,7 @@ Example Use Cases
 2. Building tutorials that include code samples from actual files
 3. Assembling documentation with custom introductions and transitions
 4. Creating prompt templates with dynamic content from different sources
+5. Including quotes or references inline without disrupting paragraph flow
 
 Tips for Using Live Bundles
 -------------------------
@@ -80,6 +115,8 @@ Tips for Using Live Bundles
 - Use relative paths when possible for portability
 - Consider using line references to include only relevant parts of files
 - Test your live bundles to ensure file paths are correctly resolved
+- Use inline inclusion (@[file]) for short snippets that should flow within text
+- Use full-line inclusion for larger blocks of content
 
 Command Line Usage
 ----------------

--- a/docs/specifying_files.txt
+++ b/docs/specifying_files.txt
@@ -39,3 +39,15 @@ Three ways to tell nanodoc which files to bundle:
    This text appears between chapters
    This is chapter 2 content
    Conclusion
+
+   Live bundles also support inline file inclusion using the @[file path] syntax:
+   
+   This paragraph includes @[quote.txt] right in the middle of the text.
+   
+   With this syntax, the file content is inserted inline with all line breaks
+   removed. This is useful for including short snippets of text within a paragraph.
+   
+   Example:
+   If quote.txt contains "to be or not to be\nthat is the question", the result will be:
+   
+   This paragraph includes to be or not to be that is the question right in the middle of the text.


### PR DESCRIPTION
We've implemented a new feature for live bundles that allows inline file inclusion using the @[file path] syntax.
We've modified the process_mixed_content_bundle function to handle this new syntax.
We've added tests for the new feature.
We've updated the documentation to explain the new feature.
Here's a summary of the changes:
Implementation:
Added code to detect and process @[file path] patterns in the text
Replaced these patterns with the content of the referenced files, with line breaks removed
Ensured that multiple inline references in a single line are handled correctly
Tests:
Added test_inline_file_inclusion to test basic inline file inclusion
Added test_real_world_inline_example to test a real-world use case
Documentation:
Updated specifying_files.txt to include information about the new feature
Updated live_bundles.txt with detailed information about inline file inclusion
Updated the example file to demonstrate the new feature
The new feature allows users to include file content inline within text, which is particularly useful for including short snippets of text within paragraphs without disrupting the flow of the document. This enhances the flexibility of nanodoc's live bundle feature.
