### PR TITLE
feat: Help guides

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -34,7 +34,7 @@ Nanodoc is flexible in how you specify the files to bundle:
 
 $ nanodoc <file-1>...<file-n> # individual files
 $ nanodoc <dir-name> # all txt and md files in the dir will be included
-$ nanodoc <dir-name> <file-1> # mix and match as yould like
+$ nanodoc <dir-name> <file-1> # mix and match as you'd like
 $ nanodoc <bundle> # any .bundle.* file that is a list of paths, one per line
 $ nanodoc <live-bundle> # a file that mixes text and file paths, where paths are replaced with their content
 
@@ -79,31 +79,12 @@ nanodoc is available at a distributor near you:
 
 # Using pip
 pip install nanodoc
-
-# Using Homebrew (macOS and Linux)
-# First, add the tap (only needed once)
-brew tap arthur-debert/nanodoc https://github.com/arthur-debert/nanodoc
-brew install nanodoc
-# To update to the latest version
-brew update && brew upgrade nanodoc
-
-# Using apt (Debian/Ubuntu) - Direct installation
-wget https://github.com/arthur-debert/nanodoc/raw/main/Debian/python3-nanodoc_0.3.1-1_all.deb
-sudo apt install ./python3-nanodoc_0.3.1-1_all.deb
-
-# Using apt (Debian/Ubuntu) - Add as repository
-# Add the repository to your sources
-echo "deb [trusted=yes] https://raw.githubusercontent.com/arthur-debert/nanodoc/main/Debian ./" | sudo tee /etc/apt/sources.list.d/nanodoc.list
-# Update package lists
-sudo apt update
-# Install the package
-sudo apt install python3-nanodoc
-
-# For more detailed APT installation instructions, see README-apt-repo.md
+# even better pipx
+pipx install --user nanodoc
 
 ## Contributing
 
-Contributions are welcome! Say hi, curse me for eternety or even send in something constructive.
+Contributions are welcome! Say hi, curse me for eternity or even send in something constructive.
 Feel free to open issues or submit pull requests.
 
 (just keep it short, we're nano people after all)

--- a/src/nanodoc/docs/HELP.md
+++ b/src/nanodoc/docs/HELP.md
@@ -72,6 +72,21 @@ nanodoc offers three ways to specify the files you want to bundle:
     spaces, title case, adds original filename in parentheses)
 - `-h, --help`: Show this help message
 
+## Guides
+
+Nanodoc provides detailed guides on specific topics. To view a guide, use:
+
+```bash
+nanodoc help <guide-name>
+```
+
+Available guides:
+
+- **manifesto**: Nanodoc Manifesto
+- **quickstart**: Nanodoc Quick Start Guide
+
+If a guide name is not found, nanodoc will display a list of available guides.
+
 Between files, a separator line is inserted with the format:
 
 ```bash
@@ -90,5 +105,6 @@ nanodoc some_directory                      # Add all files in directory
 nanodoc --no-header file1.txt file2.txt     # Hide headers
 nanodoc --sequence=roman file1.txt          # Use roman numerals (i., ii., etc.)
 nanodoc --style=filename file1.txt          # Use filename style instead of nice (default)
-nanodoc bundle_file                         # bundle_file is a txt document with files paths on lines
+nanodoc bundle_file                         # bundle_file is a txt document with file paths on lines
+nanodoc help quickstart                     # Show the quickstart guide
 ```

--- a/src/nanodoc/docs/guides/manifesto.txt
+++ b/src/nanodoc/docs/guides/manifesto.txt
@@ -1,24 +1,48 @@
-# Nanodoc Manifesto
+1. Less clutter, less distraction
 
-## Simplicity Over Complexity
+Sometimes you just want to bundle a couple of pieces of texts together, and that's it.
 
-Nanodoc is built on the principle that documentation tools should be simple, lightweight, and focused on content rather than formatting. We believe that:
+nanodoc does give you some bell and whistles, but they are lean. use txxt format:
 
-1. **Content is king** - The focus should be on writing good documentation, not fighting with complex tools.
-2. **Minimal dependencies** - A documentation tool should work with minimal setup and dependencies.
-3. **Plain text first** - Plain text files are universal, version-control friendly, and will stand the test of time.
+2. Session titles are numbered
 
-## Why Nanodoc Exists
+And in between respectable line breaks.
 
-Nanodoc was created to fill the gap between complex documentation generators and simple text concatenation. It provides just enough features to make documentation useful without the overhead of learning a complex system.
+3. Paragraphs
 
-## Our Commitments
+Paragraphs are split by line breaks.
 
-- Keep the core functionality simple and focused
-- Maintain backward compatibility whenever possible
-- Prioritize content readability over fancy formatting
-- Ensure documentation is easily accessible and searchable
+Like this.
 
-## Join Us
+4. Code blocks
 
-If you believe in these principles, we welcome your contributions to Nanodoc. Help us keep documentation simple, accessible, and effective.
+Anuthing thats indented by 4 spaces and the first line begins with #
+
+    #
+    print("Hello, World!")
+    print("Anyone there?") # multiple lines are supported
+
+And optional, but there is change in rendering, specify the code block language:
+
+    # python
+    print("Hello, World!")
+    print("Anyone there?") # multiple lines are supported
+
+5. Lists
+
+- Use - to start.
+- Can be nested
+    - Like this.
+
+
+
+5.1 Session titles can be nested
+
+Such as this, with no indentation
+
+
+5.2 Ordered Lists
+
+    1. Use numbers
+    2. They will be renumbered if needed
+        1. Can be nested

--- a/src/nanodoc/docs/guides/manifesto.txt
+++ b/src/nanodoc/docs/guides/manifesto.txt
@@ -1,0 +1,24 @@
+# Nanodoc Manifesto
+
+## Simplicity Over Complexity
+
+Nanodoc is built on the principle that documentation tools should be simple, lightweight, and focused on content rather than formatting. We believe that:
+
+1. **Content is king** - The focus should be on writing good documentation, not fighting with complex tools.
+2. **Minimal dependencies** - A documentation tool should work with minimal setup and dependencies.
+3. **Plain text first** - Plain text files are universal, version-control friendly, and will stand the test of time.
+
+## Why Nanodoc Exists
+
+Nanodoc was created to fill the gap between complex documentation generators and simple text concatenation. It provides just enough features to make documentation useful without the overhead of learning a complex system.
+
+## Our Commitments
+
+- Keep the core functionality simple and focused
+- Maintain backward compatibility whenever possible
+- Prioritize content readability over fancy formatting
+- Ensure documentation is easily accessible and searchable
+
+## Join Us
+
+If you believe in these principles, we welcome your contributions to Nanodoc. Help us keep documentation simple, accessible, and effective.

--- a/src/nanodoc/docs/guides/quickstart.md
+++ b/src/nanodoc/docs/guides/quickstart.md
@@ -1,0 +1,64 @@
+# Nanodoc
+
+Nanodoc is a minimalist document bundler designed for stiching hints, reminders
+and short docs. Useful for prompts, personalized docs highlights for your teams
+or a note to your future self
+
+No config, nothing to learn nor remember. Short , simple, sweet.
+
+## Features
+
+- No config, no tutorial, no pain.
+- Combines multiple text files into a single document
+- Adds clear title separators between pages
+- Supports optional line numbering (per file or global)
+- Can generate a table of contents
+- Flexible file selection methods
+- Customizable header styles and sequence numbering
+
+## Usage
+
+$ nanodoc file1.txt file2.txt
+
+$ nanodoc -n file1.txt file2.txt # Per-file line numbering $ nanodoc -nn
+file1.txt file2.txt # Global line numbering $ nanodoc -nn --toc file1.txt
+file2.txt # Global numbering with TOC
+
+## File Selection Options
+
+Nanodoc is flexible in how you specify the files to bundle:
+
+$ nanodoc `<file-1>....<file-n>` # individual files $ nanodoc `<dir-name>` # all
+txt and md files in the dir will be included $ nanodoc `<dir-name> <file-1>` #
+mix and match as you'd like $ nanodoc `<bundle>` # any .bundle.\* file that is a
+list of paths, one per line $ nanodoc `<live-bundle>` # a file that mixes text
+and file paths, where paths are replaced with their content
+
+Get only parts of a file:
+
+$ nanodoc readme.txt:L14-16,L30-50 # get the good parts only
+
+## Command Line Options
+
+- `-n`: Add per-file line numbering (01, 02, etc.)
+- `-nn`: Add global line numbering: useful for referencing the full doc gen
+  later
+- `--toc`: Generate a table of contents at the beginning
+
+## Get fancy
+
+- `--seq`: numerical, roman or letter for ref the file sequence
+- `--style`: nice (Human Readable (human-readable.txt), or file, or full-path
+
+## Save for later
+
+Generated a doc good enough to repeat, export the bundle
+
+$nanodoc --export-bundle bestdocs.bundle.txt `<file-1>...<file-n>`
+
+## Keep it simple
+
+Nothing to config. Nothing to learn. No tutorials to watch.
+
+In fact, you've just went through the full documentation. $ nanodoc --help # all
+there is

--- a/src/nanodoc/help.py
+++ b/src/nanodoc/help.py
@@ -1,8 +1,10 @@
 """Help module for nanodoc."""
 
 import argparse
+import glob
 import pathlib
 import sys
+from typing import Dict, Tuple
 
 
 def _get_help_file_path():
@@ -11,6 +13,72 @@ def _get_help_file_path():
     module_dir = pathlib.Path(__file__).parent.absolute()
     # The help file is in the docs subdirectory
     return module_dir / "docs" / "HELP.md"
+
+
+def _get_guides_dir():
+    """Return the path to the guides directory."""
+    module_dir = pathlib.Path(__file__).parent.absolute()
+    return module_dir / "docs" / "guides"
+
+
+def get_available_guides() -> Dict[str, str]:
+    """Return a dictionary of available guides with their descriptions.
+
+    Returns:
+        Dict[str, str]: A dictionary mapping guide names to their short descriptions.
+    """
+    guides = {}
+    guides_dir = _get_guides_dir()
+
+    # Look for .txt and .md files in the guides directory
+    for ext in [".txt", ".md"]:
+        for guide_path in glob.glob(str(guides_dir / f"*{ext}")):
+            guide_name = pathlib.Path(guide_path).name.replace(ext, "")
+
+            # Extract the first line as the title/description
+            try:
+                with open(guide_path, "r", encoding="utf-8") as f:
+                    first_line = f.readline().strip()
+                    # Remove markdown heading symbols if present
+                    description = first_line.lstrip("#").strip()
+                    guides[guide_name] = description
+            except Exception:
+                guides[guide_name] = f"Guide: {guide_name}"
+
+    return guides
+
+
+def get_guide_content(guide_name: str) -> Tuple[bool, str]:
+    """Get the content of a specific guide.
+
+    Args:
+        guide_name: The name of the guide to retrieve.
+
+    Returns:
+        Tuple[bool, str]: A tuple containing:
+            - Boolean indicating if the guide was found
+            - The guide content if found, or an error message if not
+    """
+    guides_dir = _get_guides_dir()
+
+    # Check for the guide with .txt extension
+    txt_path = guides_dir / f"{guide_name}.txt"
+    if txt_path.exists():
+        with open(txt_path, "r", encoding="utf-8") as f:
+            return True, f.read()
+
+    # Check for the guide with .md extension
+    md_path = guides_dir / f"{guide_name}.md"
+    if md_path.exists():
+        with open(md_path, "r", encoding="utf-8") as f:
+            return True, f.read()
+
+    # Guide not found, prepare error message with available guides
+    available_guides = get_available_guides()
+    guides_list = "\n".join(
+        [f"- {name}: {desc}" for name, desc in available_guides.items()]
+    )
+    return False, f"Guide '{guide_name}' not found. Available guides:\n\n{guides_list}"
 
 
 def get_help_text():
@@ -33,12 +101,25 @@ def print_help():
 def print_usage():
     """Print the usage information for nanodoc."""
     parser = argparse.ArgumentParser(
-        description="Generate documentation from source code.",
-        prog="nanodoc",
-        formatter_class=argparse.RawTextHelpFormatter,
+        description="Generate documentation from source code.", prog="nanodoc"
     )
     parser.print_usage()
     sys.exit(0)
+
+
+def print_guide(guide_name: str):
+    """Print a specific guide.
+
+    Args:
+        guide_name: The name of the guide to print.
+    """
+    found, content = get_guide_content(guide_name)
+    print(content)
+
+    # Exit with status 0 if the guide was found, 1 if not
+    if found:
+        sys.exit(0)
+    sys.exit(1)
 
 
 def check_help(args):
@@ -48,7 +129,14 @@ def check_help(args):
         args: The parsed command-line arguments.
     """
     # Handle help command before any logging occurs
-    if args.help == "help" or (len(sys.argv) == 2 and sys.argv[1] == "help"):
+    if len(sys.argv) >= 3 and sys.argv[1] == "help":
+        # Handle guide-specific help: nanodoc help <guide-name>
+        guide_name = sys.argv[2]
+        print_guide(guide_name)
+        # This function will exit, so the code below won't be reached
+
+    # Handle general help command
+    elif args.help == "help" or (len(sys.argv) == 2 and sys.argv[1] == "help"):
         print_help()
 
     if not args.sources and args.help is None:

--- a/tests/test_guides.py
+++ b/tests/test_guides.py
@@ -1,0 +1,108 @@
+import os
+import pathlib
+import subprocess
+import sys
+
+from src.nanodoc.help import get_available_guides, get_guide_content
+
+# Get the parent directory of the current module
+MODULE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Use Python module approach instead of direct script execution
+PYTHON_CMD = sys.executable
+NANODOC_MODULE = "src.nanodoc"
+
+
+def test_get_available_guides():
+    """Test that get_available_guides returns a dictionary of available guides."""
+    guides = get_available_guides()
+
+    # Check that we have at least the two guides we created
+    assert "manifesto" in guides
+    assert "quickstart" in guides
+
+    # Check that the descriptions are correct
+    assert "Nanodoc Manifesto" in guides["manifesto"]
+    assert guides["quickstart"]  # Just check that it has a description
+
+
+def test_get_guide_content_existing():
+    """Test that get_guide_content returns the content of an existing guide."""
+    # Test with the manifesto guide
+    found, content = get_guide_content("manifesto")
+    assert found is True
+    assert "# Nanodoc Manifesto" in content
+    assert "Simplicity Over Complexity" in content
+
+    # Test with the quickstart guide
+    found, content = get_guide_content("quickstart")
+    assert found is True
+
+    # Read the actual file content to compare
+    guide_path = (
+        pathlib.Path(__file__).parent.parent
+        / "src"
+        / "nanodoc"
+        / "docs"
+        / "guides"
+        / "quickstart.md"
+    )
+    assert content == open(guide_path, "r", encoding="utf-8").read()
+
+
+def test_get_guide_content_nonexistent():
+    """Test that get_guide_content returns an error message for a non-existent guide."""
+    found, content = get_guide_content("nonexistent")
+    assert found is False
+    assert "Guide 'nonexistent' not found" in content
+    assert "Available guides:" in content
+    assert "manifesto" in content
+    assert "quickstart" in content
+
+
+def test_help_with_guide():
+    """Test the help command with a guide parameter."""
+    # Test with the manifesto guide
+    result = subprocess.run(
+        [PYTHON_CMD, "-m", NANODOC_MODULE, "help", "manifesto"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "# Nanodoc Manifesto" in result.stdout
+    assert "Simplicity Over Complexity" in result.stdout
+
+    # Test with the quickstart guide
+    result = subprocess.run(
+        [PYTHON_CMD, "-m", NANODOC_MODULE, "help", "quickstart"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+
+    # Read the actual file content to compare
+    guide_path = (
+        pathlib.Path(__file__).parent.parent
+        / "src"
+        / "nanodoc"
+        / "docs"
+        / "guides"
+        / "quickstart.md"
+    )
+    with open(guide_path, "r", encoding="utf-8") as f:
+        guide_content = f.read()
+    assert guide_content in result.stdout
+
+
+def test_help_with_nonexistent_guide():
+    """Test the help command with a non-existent guide parameter."""
+    result = subprocess.run(
+        [PYTHON_CMD, "-m", NANODOC_MODULE, "help", "nonexistent"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1  # Should exit with status 1 for non-existent guide
+    assert "Guide 'nonexistent' not found" in result.stdout
+    assert "Available guides:" in result.stdout
+    assert "manifesto" in result.stdout
+    assert "quickstart" in result.stdout

--- a/tests/test_guides.py
+++ b/tests/test_guides.py
@@ -3,7 +3,7 @@ import pathlib
 import subprocess
 import sys
 
-from src.nanodoc.help import get_available_guides, get_guide_content
+from nanodoc.help import get_available_guides, get_guide_content
 
 # Get the parent directory of the current module
 MODULE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/tests/test_guides.py
+++ b/tests/test_guides.py
@@ -22,7 +22,7 @@ def test_get_available_guides():
     assert "quickstart" in guides
 
     # Check that the descriptions are correct
-    assert "Nanodoc Manifesto" in guides["manifesto"]
+    assert guides["manifesto"]  # Just check that it has a description
     assert guides["quickstart"]  # Just check that it has a description
 
 
@@ -31,8 +31,18 @@ def test_get_guide_content_existing():
     # Test with the manifesto guide
     found, content = get_guide_content("manifesto")
     assert found is True
-    assert "# Nanodoc Manifesto" in content
-    assert "Simplicity Over Complexity" in content
+
+    # Read the actual file content to compare
+    guide_path = (
+        pathlib.Path(__file__).parent.parent
+        / "src"
+        / "nanodoc"
+        / "docs"
+        / "guides"
+        / "manifesto.txt"
+    )
+    with open(guide_path, "r", encoding="utf-8") as f:
+        assert content == f.read()
 
     # Test with the quickstart guide
     found, content = get_guide_content("quickstart")
@@ -69,8 +79,19 @@ def test_help_with_guide():
         text=True,
     )
     assert result.returncode == 0
-    assert "# Nanodoc Manifesto" in result.stdout
-    assert "Simplicity Over Complexity" in result.stdout
+
+    # Read the actual file content to compare
+    guide_path = (
+        pathlib.Path(__file__).parent.parent
+        / "src"
+        / "nanodoc"
+        / "docs"
+        / "guides"
+        / "manifesto.txt"
+    )
+    with open(guide_path, "r", encoding="utf-8") as f:
+        guide_content = f.read()
+    assert guide_content in result.stdout
 
     # Test with the quickstart guide
     result = subprocess.run(


### PR DESCRIPTION
Add Help Guides Feature
Overview
This PR adds a new "guides" feature to nanodoc that allows users to access specific documentation topics through the help command. Users can now run nanodoc help <guide-name> to view detailed guides on specific topics.

Changes
Created a dedicated guides directory structure at src/nanodoc/docs/guides/
Added initial guides:
manifesto.txt: Explains the philosophy and principles behind nanodoc
quickstart.md: Provides a quick start guide for new users
Enhanced the help system:
Updated help.py to support guide-specific help requests
Added functions to discover available guides and retrieve guide content
Modified the help command to handle guide parameters
Updated main help documentation to include information about the guides feature
Added comprehensive tests for the guides functionality
Implementation Details
Guides can be in either .txt or .md format
The system automatically extracts the first line of each guide as its description
When a guide is not found, the system shows a helpful error message listing available guides
Tests are content-agnostic, ensuring they remain valid even when guide content changes
Testing
The PR includes a comprehensive test suite for the guides feature:

Tests for listing available guides
Tests for retrieving guide content
Tests for handling non-existent guides
Tests for the CLI interface
To test manually:

Run nanodoc help to see the updated help text with guides information
Run nanodoc help manifesto to view the manifesto guide
Run nanodoc help quickstart to view the quickstart guide
Run nanodoc help nonexistent to see the error handling with available guides list