### PR TITLE
Improve Dry-run output

### DIFF
--- a/cmd/nanodoc/root.go
+++ b/cmd/nanodoc/root.go
@@ -63,30 +63,7 @@ var rootCmd = &cobra.Command{
 		// Track explicitly set flags
 		trackExplicitFlags(cmd)
 
-		// 1. Resolve Paths with pattern options
-		pathOpts := &nanodoc.FormattingOptions{
-			AdditionalExtensions: additionalExt,
-			IncludePatterns: includePatterns,
-			ExcludePatterns: excludePatterns,
-		}
-		pathInfos, err := nanodoc.ResolvePathsWithOptions(args, pathOpts)
-		if err != nil {
-			return fmt.Errorf(ErrResolvingPaths, err)
-		}
-
-		// If dry run, show what would be processed and exit
-		if dryRun {
-			dryRunInfo, err := nanodoc.GenerateDryRunInfo(pathInfos, additionalExt)
-			if err != nil {
-				return fmt.Errorf(ErrGeneratingDryRun, err)
-			}
-			
-			output := nanodoc.FormatDryRunOutput(dryRunInfo)
-			_, _ = fmt.Fprint(cmd.OutOrStdout(), output)
-			return nil
-		}
-
-		// 2. Set up Formatting Options
+		// 1. Set up Formatting Options first
 		lineNumberMode := nanodoc.LineNumberNone
 		switch lineNum {
 		case "file":
@@ -109,6 +86,29 @@ var rootCmd = &cobra.Command{
 			AdditionalExtensions: additionalExt,
 			IncludePatterns: includePatterns,
 			ExcludePatterns: excludePatterns,
+		}
+
+		// 2. Resolve Paths with pattern options
+		pathOpts := &nanodoc.FormattingOptions{
+			AdditionalExtensions: additionalExt,
+			IncludePatterns: includePatterns,
+			ExcludePatterns: excludePatterns,
+		}
+		pathInfos, err := nanodoc.ResolvePathsWithOptions(args, pathOpts)
+		if err != nil {
+			return fmt.Errorf(ErrResolvingPaths, err)
+		}
+
+		// If dry run, show what would be processed and exit
+		if dryRun {
+			dryRunInfo, err := nanodoc.GenerateDryRunInfo(pathInfos, opts)
+			if err != nil {
+				return fmt.Errorf(ErrGeneratingDryRun, err)
+			}
+			
+			output := nanodoc.FormatDryRunOutput(dryRunInfo)
+			_, _ = fmt.Fprint(cmd.OutOrStdout(), output)
+			return nil
 		}
 
 		// 3. Build Document with explicit flags


### PR DESCRIPTION
- Show line counts instead of file sizes and modification times
- Respect line ranges when counting lines (e.g., file.txt:L10-20 shows 11 lines)
- Display total line count including headers and TOC if enabled
- Show active formatting options in the output
- Update tests to cover new functionality

The dry run output now provides more relevant information for document
bundling by focusing on line counts rather than file metadata.

Closes #34

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
