### PR TITLE
Fix: Preserve user-specified file order

### DIFF
--- a/pkg/nanodoc/bundle_order_test.go
+++ b/pkg/nanodoc/bundle_order_test.go
@@ -1,0 +1,163 @@
+package nanodoc
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBundlePreservesFileOrder(t *testing.T) {
+	// Create temp directory
+	tempDir, err := os.MkdirTemp("", "nanodoc-bundle-order-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
+
+	// Create test files with names that would sort differently alphabetically
+	fileZ := filepath.Join(tempDir, "z-file.txt")
+	fileA := filepath.Join(tempDir, "a-file.txt")
+	fileM := filepath.Join(tempDir, "m-file.txt")
+	
+	// Write distinct content to each file
+	if err := os.WriteFile(fileZ, []byte("Content Z"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fileA, []byte("Content A"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(fileM, []byte("Content M"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create bundle file with specific order: Z, A, M
+	bundleFile := filepath.Join(tempDir, "test.bundle.txt")
+	bundleContent := strings.Join([]string{fileZ, fileA, fileM}, "\n")
+	if err := os.WriteFile(bundleFile, []byte(bundleContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Process the bundle
+	bp := NewBundleProcessor()
+	paths, err := bp.ProcessBundleFile(bundleFile)
+	if err != nil {
+		t.Fatalf("ProcessBundleFile() error = %v", err)
+	}
+
+	// Check that the order is preserved
+	expectedOrder := []string{fileZ, fileA, fileM}
+	if len(paths) != len(expectedOrder) {
+		t.Fatalf("ProcessBundleFile() returned %d paths, want %d", len(paths), len(expectedOrder))
+	}
+
+	for i, path := range paths {
+		if path != expectedOrder[i] {
+			t.Errorf("ProcessBundleFile() path[%d] = %s, want %s", i, path, expectedOrder[i])
+		}
+	}
+
+	// Now test the full document building to ensure order is preserved through the pipeline
+	pathInfos := []PathInfo{
+		{
+			Original: bundleFile,
+			Absolute: bundleFile,
+			Type:     "bundle",
+		},
+	}
+
+	doc, err := BuildDocument(pathInfos, FormattingOptions{ShowHeaders: false})
+	if err != nil {
+		t.Fatalf("BuildDocument() error = %v", err)
+	}
+
+	// Check that content appears in the correct order
+	if len(doc.ContentItems) != 3 {
+		t.Fatalf("BuildDocument() created %d content items, want 3", len(doc.ContentItems))
+	}
+
+	// Verify content order
+	expectedContents := []string{"Content Z", "Content A", "Content M"}
+	for i, item := range doc.ContentItems {
+		if strings.TrimSpace(item.Content) != expectedContents[i] {
+			t.Errorf("BuildDocument() content[%d] = %q, want %q", i, strings.TrimSpace(item.Content), expectedContents[i])
+		}
+	}
+}
+
+func TestBundleWithMixedSourcesPreservesOrder(t *testing.T) {
+	// Create temp directory
+	tempDir, err := os.MkdirTemp("", "nanodoc-bundle-mixed-order-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
+
+	// Create test files
+	file1 := filepath.Join(tempDir, "1-file.txt")
+	file2 := filepath.Join(tempDir, "2-file.txt")
+	file3 := filepath.Join(tempDir, "3-file.txt")
+	file4 := filepath.Join(tempDir, "4-file.txt")
+	
+	// Write distinct content
+	files := map[string]string{
+		file1: "Content 1",
+		file2: "Content 2",
+		file3: "Content 3",
+		file4: "Content 4",
+	}
+	
+	for file, content := range files {
+		if err := os.WriteFile(file, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create bundle with files 3 and 1
+	bundleFile := filepath.Join(tempDir, "test.bundle.txt")
+	bundleContent := strings.Join([]string{file3, file1}, "\n")
+	if err := os.WriteFile(bundleFile, []byte(bundleContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test with mixed sources: file4, bundle (containing 3,1), file2
+	pathInfos := []PathInfo{
+		{
+			Original: file4,
+			Absolute: file4,
+			Type:     "file",
+		},
+		{
+			Original: bundleFile,
+			Absolute: bundleFile,
+			Type:     "bundle",
+		},
+		{
+			Original: file2,
+			Absolute: file2,
+			Type:     "file",
+		},
+	}
+
+	doc, err := BuildDocument(pathInfos, FormattingOptions{ShowHeaders: false})
+	if err != nil {
+		t.Fatalf("BuildDocument() error = %v", err)
+	}
+
+	// Expected order: 4, 3, 1, 2
+	expectedContents := []string{"Content 4", "Content 3", "Content 1", "Content 2"}
+	
+	if len(doc.ContentItems) != len(expectedContents) {
+		t.Fatalf("BuildDocument() created %d content items, want %d", len(doc.ContentItems), len(expectedContents))
+	}
+
+	for i, item := range doc.ContentItems {
+		if strings.TrimSpace(item.Content) != expectedContents[i] {
+			t.Errorf("BuildDocument() content[%d] = %q, want %q", i, strings.TrimSpace(item.Content), expectedContents[i])
+		}
+	}
+}

--- a/pkg/nanodoc/resolver.go
+++ b/pkg/nanodoc/resolver.go
@@ -44,9 +44,8 @@ func ResolvePathsWithOptions(sources []string, options *FormattingOptions) ([]Pa
 		results = append(results, pathInfo)
 	}
 
-	sort.Slice(results, func(i, j int) bool {
-		return results[i].Absolute < results[j].Absolute
-	})
+	// Preserve the order of paths as provided by the user
+	// Do not sort - the user's specified order is intentional
 
 	return results, nil
 }

--- a/pkg/nanodoc/resolver_order_test.go
+++ b/pkg/nanodoc/resolver_order_test.go
@@ -1,0 +1,125 @@
+package nanodoc
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolvePathsPreservesOrder(t *testing.T) {
+	// Create temp directory
+	tempDir, err := os.MkdirTemp("", "nanodoc-order-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
+
+	// Create test files with names that would sort differently alphabetically
+	fileZ := filepath.Join(tempDir, "z-file.txt")
+	fileA := filepath.Join(tempDir, "a-file.txt")
+	fileM := filepath.Join(tempDir, "m-file.txt")
+	
+	for _, file := range []string{fileZ, fileA, fileM} {
+		if err := os.WriteFile(file, []byte("content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Test cases with different orderings
+	tests := []struct {
+		name     string
+		sources  []string
+		wantOrder []string
+	}{
+		{
+			name:     "z-a-m order",
+			sources:  []string{fileZ, fileA, fileM},
+			wantOrder: []string{fileZ, fileA, fileM},
+		},
+		{
+			name:     "m-z-a order",
+			sources:  []string{fileM, fileZ, fileA},
+			wantOrder: []string{fileM, fileZ, fileA},
+		},
+		{
+			name:     "a-m-z order (alphabetical)",
+			sources:  []string{fileA, fileM, fileZ},
+			wantOrder: []string{fileA, fileM, fileZ},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, err := ResolvePaths(tt.sources)
+			if err != nil {
+				t.Fatalf("ResolvePaths() error = %v", err)
+			}
+
+			if len(results) != len(tt.wantOrder) {
+				t.Fatalf("ResolvePaths() returned %d results, want %d", len(results), len(tt.wantOrder))
+			}
+
+			// Check that the order is preserved
+			for i, result := range results {
+				if result.Absolute != tt.wantOrder[i] {
+					t.Errorf("ResolvePaths() result[%d] = %s, want %s", i, result.Absolute, tt.wantOrder[i])
+				}
+			}
+		})
+	}
+}
+
+func TestResolvePathsWithDirectoryPreservesOrder(t *testing.T) {
+	// Create temp directory
+	tempDir, err := os.MkdirTemp("", "nanodoc-order-dir-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tempDir)
+	}()
+
+	// Create subdirectories
+	dirA := filepath.Join(tempDir, "a-dir")
+	dirZ := filepath.Join(tempDir, "z-dir")
+	
+	for _, dir := range []string{dirA, dirZ} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create files in directories
+	fileInA := filepath.Join(dirA, "file.txt")
+	fileInZ := filepath.Join(dirZ, "file.txt")
+	standaloneFile := filepath.Join(tempDir, "standalone.txt")
+	
+	for _, file := range []string{fileInA, fileInZ, standaloneFile} {
+		if err := os.WriteFile(file, []byte("content"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Test with mixed directory and file arguments
+	sources := []string{dirZ, standaloneFile, dirA}
+	
+	results, err := ResolvePaths(sources)
+	if err != nil {
+		t.Fatalf("ResolvePaths() error = %v", err)
+	}
+
+	// We expect 3 PathInfo entries in the order: dirZ, standaloneFile, dirA
+	if len(results) != 3 {
+		t.Fatalf("ResolvePaths() returned %d results, want 3", len(results))
+	}
+
+	// Check order - directories should be in the order specified
+	expectedOrder := []string{dirZ, standaloneFile, dirA}
+	for i, result := range results {
+		if result.Absolute != expectedOrder[i] {
+			t.Errorf("ResolvePaths() result[%d].Absolute = %s, want %s", i, result.Absolute, expectedOrder[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Removes alphabetical sorting of input files to preserve the user's intended order
- Fixes issue where `nanodoc fileb.txt filea.txt` would output file A before file B

## Changes
- Removed sorting in `resolver.go` that was reordering top-level path arguments
- Files within directories continue to be sorted for consistency
- Added comprehensive tests for both command-line arguments and bundle files

## Test Plan
- [x] Added `resolver_order_test.go` to test command-line argument ordering
- [x] Added `bundle_order_test.go` to test bundle file ordering
- [x] All existing tests pass
- [x] Manual testing confirms the fix works:
  ```bash
  # Before: would output "First" then "Second" then "Third"
  # After: outputs in the specified order
  nanodoc third.txt first.txt second.txt
  ```

Fixes #35

🤖 Generated with [Claude Code](https://claude.ai/code)