### PR TITLE
docs: update documentation for CLI/UI changes

### DIFF
--- a/cmd/nanodoc/docs/bundles.txt
+++ b/cmd/nanodoc/docs/bundles.txt
@@ -16,9 +16,9 @@ Basic Bundle Syntax
 
         # --- Options ---
         --toc
-        --global-line-numbers
-        --header-style nice
-        --sequence roman
+        --linenum global
+        --file-style nice
+        --file-numbering roman
         --theme classic-dark
 
         # --- Content ---
@@ -33,13 +33,12 @@ Supported Options
 All formatting options are supported in bundle files:
 
     - --toc - Generate a table of contents
-    - --line-numbers or -n - Enable per-file line numbering
-    - --global-line-numbers or -N - Enable global line numbering
+    - --linenum <mode> or -l <mode> - Enable line numbering (file or global)
     - --theme <name> - Set the theme (classic, classic-dark, classic-light)
-    - --header-style <style> - Set header style (nice, filename, path)
-    - --sequence <style> - Set sequence style (numerical, letter, roman)
-    - --no-header - Suppress file headers
-    - --txt-ext <ext> - Additional file extensions to treat as text
+    - --file-style <style> - Set filename display style (nice, filename, path)
+    - --file-numbering <style> - Set file numbering style (numerical, alphabetical, roman)
+    - --filenames=false - Hide file headers (default: true)
+    - --ext <ext> - Additional file extensions to treat as text
     - --include <pattern> - Include only files matching patterns
     - --exclude <pattern> - Exclude files matching patterns
 
@@ -57,8 +56,8 @@ Example: Development vs Production Bundles
 
 dev.bundle.txt:
     -- 
-        --line-numbers
-        --header-style path
+        --linenum file
+        --file-style path
         --theme classic
 
         src/
@@ -68,10 +67,10 @@ dev.bundle.txt:
 release.bundle.txt:
     -- 
         --toc
-        --global-line-numbers
-        --sequence letter
+        --linenum global
+        --file-numbering alphabetical
         --theme classic-dark
-        --no-header
+        --filenames=false
 
         README.md
         CHANGELOG.md
@@ -238,13 +237,12 @@ Bundle files can include formatting options that apply to the entire bundle. Opt
 Supported Options in Bundles
 
     --toc                      Generate a table of contents
-    --line-numbers, -n         Enable per-file line numbering
-    --global-line-numbers, -N  Enable global line numbering
+    --linenum <mode>, -l       Enable line numbering (file or global)
     --theme <name>             Set theme (classic, classic-dark, classic-light)
-    --header-style <style>     Set header style (nice, filename, path)
-    --sequence <style>         Set sequence style (numerical, letter, roman)
-    --no-header                Suppress file headers
-    --txt-ext <ext>            Additional file extensions to treat as text
+    --file-style <style>       Set filename display style (nice, filename, path)
+    --file-numbering <style>   Set file numbering style (numerical, alphabetical, roman)
+    --filenames[=bool]         Show/hide file headers (default: true)
+    --ext <ext>                Additional file extensions to treat as text
     --include <pattern>        Include only files matching patterns
     --exclude <pattern>        Exclude files matching patterns
 

--- a/cmd/nanodoc/docs/content.txt
+++ b/cmd/nanodoc/docs/content.txt
@@ -16,14 +16,14 @@ Glob patterns are handled internally by nanodoc using gitignore-style matching. 
 1. How Directory Expansion Works:
 
   1. When expanding a directory, nanodoc will filter by file extensions. By default those are `.txt` and `.md`
-  2. Additional extensions like js or py can be added with the --txt-ext option.
+  2. Additional extensions like js or py can be added with the --ext option.
 
 
 2. The include and exclude options:
 
      Both options use glob patterns. For directory expansion, they filter files
      AFTER extension checking. This means --include alone cannot override the
-     extension filter - you must use --txt-ext to add extensions first.
+     extension filter - you must use --ext to add extensions first.
 
      However, when using glob patterns as arguments (e.g., **/*.js), the extension filter is bypassed entirely. 
 
@@ -79,8 +79,29 @@ Glob patterns are handled internally by nanodoc using gitignore-style matching. 
 
 		--
 		# Process Python files
-		nanodoc --txt-ext py src/
+		nanodoc --ext py src/
 
 		# Multiple extensions
-		nanodoc --txt-ext py --txt-ext js --txt-ext yaml project/
+		nanodoc --ext py --ext js --ext yaml project/
 		--
+
+
+5. File Order Preservation
+
+	Nanodoc preserves the order of files exactly as you specify them. This is important for maintaining document flow and logical structure.
+
+		-- file order examples:
+		
+			# Files are processed in the exact order given
+			nanodoc intro.md main.go appendix.md
+			# Result: intro.md first, then main.go, then appendix.md
+
+			# When using globs, files are sorted alphabetically within each pattern
+			nanodoc intro.md **/*.go conclusion.md
+			# Result: intro.md first, all .go files (sorted), then conclusion.md
+
+			# Mix specific files and directories
+			nanodoc overview.txt src/ summary.txt
+			# Result: overview.txt, then src/ contents, then summary.txt
+		
+		-- bash

--- a/cmd/nanodoc/docs/examples/bundle_with_options.bundle.txt
+++ b/cmd/nanodoc/docs/examples/bundle_with_options.bundle.txt
@@ -6,10 +6,10 @@
 
 --toc
 --theme classic-dark
---header-style filename
---sequence roman
---global-line-numbers
---txt-ext log
+--file-style filename
+--file-numbering roman
+--linenum global
+--ext log
 
 # --- Content ---
 # Files to include in the bundle

--- a/cmd/nanodoc/docs/feat/dryrun.txt
+++ b/cmd/nanodoc/docs/feat/dryrun.txt
@@ -1,0 +1,90 @@
+DRY RUN MODE
+
+Nanodoc's dry run mode allows you to preview exactly what files will be processed and how they will be formatted before generating the actual output. This is particularly useful for understanding which files match your patterns and how many lines will be included.
+
+
+WHAT DRY RUN SHOWS
+
+When you use the --dry-run flag, nanodoc displays:
+
+    1. File Information:
+       - Path of each file that will be processed
+       - File extension  
+       - Number of lines that will be included (respecting any line ranges)
+       - Line range specification if applicable (e.g., L10-20)
+
+    2. Active Formatting Options:
+       - Which theme is active
+       - Line numbering mode (if enabled)
+       - File style and numbering settings
+       - Whether a table of contents will be generated
+
+    3. Summary Statistics:
+       - Total number of files to be processed
+       - Total number of lines that will be included
+
+
+EXAMPLE OUTPUT
+
+    -- 
+        $ nanodoc --dry-run --linenum global --theme classic-dark src/*.go docs/*.md
+
+        Dry run - no output will be generated
+        
+        Files to be processed:
+        [1] src/main.go (go) - 150 lines
+        [2] src/utils.go (go) - 75 lines
+        [3] docs/README.md (md) - 200 lines
+        [4] docs/API.md (md) - 120 lines
+        
+        Active options:
+        - Theme: classic-dark
+        - Line numbering: global
+        - File style: nice (default)
+        - File numbering: numerical (default)
+        
+        Total: 4 files, 545 lines
+    --
+
+
+LINE RANGE SUPPORT
+
+Dry run accurately shows the number of lines that will be processed when using line ranges:
+
+    -- 
+        $ nanodoc --dry-run main.go:L50-100 utils.go:L1-25
+
+        Files to be processed:
+        [1] main.go (go) - 51 lines [L50-100]
+        [2] utils.go (go) - 25 lines [L1-25]
+        
+        Total: 2 files, 76 lines
+    --
+
+
+USE CASES
+
+    1. Verifying glob patterns:
+       Check which files match your include/exclude patterns before processing
+
+    2. Estimating output size:
+       See how many lines will be in the final output
+
+    3. Debugging file selection:
+       Understand why certain files are or aren't being included
+
+    4. Testing bundles:
+       Preview what a bundle file will produce without generating output
+
+
+OPTIONS
+
+    --dry-run    Preview which files will be processed without generating output
+
+
+TIPS
+
+    - Use dry run when working with new glob patterns to ensure they match expected files
+    - Combine with --include and --exclude to test filtering rules
+    - Use with bundle files to verify their contents before processing
+    - The line counts shown respect any line range specifications

--- a/cmd/nanodoc/docs/feat/headers.txt
+++ b/cmd/nanodoc/docs/feat/headers.txt
@@ -1,11 +1,11 @@
-HEADERS AND SEQUENCING
+FILE HEADERS AND NUMBERING
 
-Nanodoc can automatically generate headers for each file included in a bundle. The appearance of these headers is controlled by two main settings: the header style and the sequence style.
+Nanodoc can automatically generate headers for each file included in a bundle. The appearance of these headers is controlled by two main settings: the file style and the file numbering style.
 
 
-HEADER STYLES
+FILE STYLES
 
-There are three available header styles:
+There are three available file styles:
 
     1. filename: Displays the simple filename (e.g., my_document.txt).
     2. path: Displays the full resolved path to the file.
@@ -17,12 +17,12 @@ There are three available header styles:
             - Converts the result to Title Case (e.g., My Document).
 
 
-SEQUENCE STYLES
+FILE NUMBERING STYLES
 
-The sequence style determines the marker placed before the header title.
+The file numbering style determines the marker placed before the header title.
 
     1. numerical (Default): 1., 2., 3.
-    2. letter: a., b., c.
+    2. alphabetical: a., b., c.
     3. roman: i., ii., iii.
 
 
@@ -37,9 +37,11 @@ Given a file named my_first_document.md, using the default nice header style and
 
 OPTIONS
 
-    --no-header             Hide headers completely
-    --sequence=TYPE         Add sequence numbers (numerical, letter, roman)
-    --header-style=STYLE    Change format (nice [default], filename, path)
+    --filenames             Show filenames between concatenated files (default: true)
+                           Use --filenames=false to hide headers completely
+    --file-numbering=TYPE   Set the file numbering style (numerical, alphabetical, roman)
+                           Default: numerical
+    --file-style=STYLE      Set the filename display style (nice [default], filename, path)
 
 
 EXAMPLES
@@ -48,6 +50,6 @@ EXAMPLES
         "File (file.txt)"       Default style (nice: titled with original in parentheses)
         "file.txt"              Filename style
         "/path/to/file.txt"     Path style (full path)
-        "1. file.txt"           With numerical sequence
-        "a. File (file.txt)"    Combined letter sequence with nice style
+        "1. file.txt"           With numerical file numbering
+        "a. File (file.txt)"    Combined alphabetical numbering with nice style
     --

--- a/cmd/nanodoc/docs/feat/line-numbering.txt
+++ b/cmd/nanodoc/docs/feat/line-numbering.txt
@@ -1,14 +1,14 @@
 LINE NUMBERING MODES
 
-Nanodoc provides two distinct modes for adding line numbers to the output.
+Nanodoc provides two distinct modes for adding line numbers to the output using a single unified flag.
 
 
 MODES
 
-    1. Per-File Numbering (-n):
+    1. Per-File Numbering:
        In this mode, line numbering restarts at 1 for each new file that is added to the bundle. This is useful when you want to see line counts relative to each individual file.
 
-    2. Global Numbering (-N):
+    2. Global Numbering:
        In this mode, line numbering is continuous across all files in the bundle. It starts at 1 for the first line of the first file and increments sequentially until the very last line of the last file. This is useful for getting a total line count or for referencing lines in the final combined document.
 
 
@@ -61,5 +61,11 @@ Global Numbering Output:
 
 OPTIONS
 
-    -n, --line-numbers         Per-file numbering: Each file starts from 1
-    -N, --global-line-numbers  Global numbering: Continues across all files
+    -l, --linenum <mode>  Enable line numbering with specified mode:
+                          • file   - Per-file numbering: Each file starts from 1
+                          • global - Global numbering: Continues across all files
+    
+    Examples:
+        nanodoc file1.txt file2.txt --linenum file      # Per-file numbering
+        nanodoc file1.txt file2.txt --linenum global    # Global numbering
+        nanodoc file1.txt file2.txt -l file             # Short form


### PR DESCRIPTION
## Summary
- Updated all documentation to reflect recent CLI flag renames from PR #36
- Added new documentation for dry run mode feature from PR #34
- Updated examples to use new flag syntax

## Changes Made

### Flag Renames Documented
- `--line-numbers/-n` and `--global-line-numbers/-N` → `--linenum/-l <file|global>`
- `--txt-ext` → `--ext`
- `--no-header` → `--filenames` (inverted logic)
- `--sequence` → `--file-numbering`
- `--header-style` → `--file-style`

### Files Updated
1. **line-numbering.txt**: Updated to show new unified `--linenum` flag syntax
2. **headers.txt**: Updated all flag names and examples
3. **content.txt**: Changed `--txt-ext` to `--ext`, added file order preservation docs
4. **bundles.txt**: Updated all flag references in examples and options lists
5. **dryrun.txt**: Created new documentation for dry run mode feature
6. **bundle_with_options.bundle.txt**: Updated example to use new flag names

## Test Plan
- [ ] Verify all flag names in docs match actual implementation
- [ ] Test example commands work with new syntax
- [ ] Confirm bundle files with new options parse correctly

Closes #38

🤖 Generated with [Claude Code](https://claude.ai/code)