### PR TITLE
feat: Complete markdown phases 2.1-2.4 implementation

### DIFF
--- a/pkg/nanodoc/renderer_test.go
+++ b/pkg/nanodoc/renderer_test.go
@@ -677,7 +677,7 @@ func TestRenderDocumentWithOutputFormat(t *testing.T) {
 				if !strings.Contains(result, "Table of Contents") {
 					t.Error("Markdown output should contain TOC when requested")
 				}
-				if !strings.Contains(result, "## 1. test.md") {
+				if !strings.Contains(result, "## 1. Test") {
 					t.Error("Markdown output should contain file header when requested")
 				}
 				// Should not have line numbers (markdown doesn't support this)
@@ -861,10 +861,10 @@ func TestRenderMarkdownEnhanced(t *testing.T) {
 				ShowFilenames: true,
 			},
 			checkFunc: func(t *testing.T, result string) {
-				if !strings.Contains(result, "## 1. doc1.md") {
+				if !strings.Contains(result, "## 1. Doc1") {
 					t.Errorf("Should contain numbered file header for doc1, got: %q", result)
 				}
-				if !strings.Contains(result, "## 2. doc2.md") {
+				if !strings.Contains(result, "## 2. Doc2") {
 					t.Errorf("Should contain numbered file header for doc2, got: %q", result)
 				}
 			},
@@ -930,11 +930,11 @@ func TestRenderMarkdownEnhanced(t *testing.T) {
 				if !strings.Contains(result, "## Table of Contents") {
 					t.Errorf("Should contain TOC, got: %q", result)
 				}
-				// Check file headers
-				if !strings.Contains(result, "## a. readme.md") {
+				// Check file headers (should be "nice" format from TOC)
+				if !strings.Contains(result, "## a. Project") {
 					t.Errorf("Should contain letter sequence file header, got: %q", result)
 				}
-				if !strings.Contains(result, "## b. guide.md") {
+				if !strings.Contains(result, "## b. Guide") {
 					t.Errorf("Should contain second file header, got: %q", result)
 				}
 				// Check header adjustment

--- a/pkg/nanodoc/structures.go
+++ b/pkg/nanodoc/structures.go
@@ -51,6 +51,9 @@ type TOCEntry struct {
 	// File path this entry refers to
 	Path string
 
+	// Heading level (1 for H1, 2 for H2, etc.)
+	Level int
+
 	// Sequence number/letter/roman numeral if applicable
 	Sequence string
 


### PR DESCRIPTION
## Summary

This PR completes the implementation of enhanced markdown support for nanodoc, covering all four phases (2.1 through 2.4). It builds upon the markdown package API introduced in #67 and integrates it fully into the nanodoc application.

## Implemented Features

### Phase 2.1 - Technical Viability POC (#64)
✅ Integrated the markdown package into nanodoc's renderer
✅ Created `renderMarkdownEnhanced` function to replace basic concatenation
✅ Validated all goldmark capabilities work correctly

### Phase 2.2 - Header Level Adjustment (#61)
✅ Automatically detect H1 headers in markdown documents
✅ Adjust header levels for documents after the first (H1→H2, H2→H3, etc.)
✅ Maintain proper document hierarchy in concatenated output

### Phase 2.3 - File Headers Support (#62)
✅ Add file headers when `--filenames` flag is used
✅ Support all sequence styles (numerical, letter, roman)
✅ Insert headers as H2 level to maintain structure
✅ Integrate with existing nanodoc formatting options

### Phase 2.4 - Table of Contents (#63)
✅ Generate markdown-formatted TOC when `--toc` flag is used
✅ Extract headers from all documents with proper nesting
✅ Prepend filenames to TOC entries for clarity
✅ Create anchor links for navigation

## Technical Details

- The implementation replaces `renderMarkdownBasic` with `renderMarkdownEnhanced`
- All existing FormattingContext options are respected
- Non-markdown files pass through unchanged
- Comprehensive test coverage for all phases
- No breaking changes to existing functionality

## Testing

All phases have been thoroughly tested:
- Unit tests for each phase individually
- Integration tests for combined functionality
- Existing tests updated to reflect new behavior
- All tests passing with full coverage

## Closes

- Closes #61 (Phase 2.2: Header Level Adjustment)
- Closes #62 (Phase 2.3: File Headers Support)
- Closes #63 (Phase 2.4: Table of Contents)
- Closes #64 (Phase 2.1: Technical Viability POC)

## Example Usage

```bash
# Basic markdown with header adjustment
nanodoc --format markdown file1.md file2.md

# With file headers
nanodoc --format markdown --filenames file1.md file2.md

# With table of contents
nanodoc --format markdown --toc file1.md file2.md

# All features combined
nanodoc --format markdown --filenames --toc --numbering letter *.md
```

## Test plan

- [x] Run all tests: `go test ./...`
- [x] Verify linting passes: `scripts/lint`
- [x] Manual testing with various markdown files
- [x] Test all formatting option combinations

🤖 Generated with [Claude Code](https://claude.ai/code)