### PR TITLE
fix: Display error messages for invalid CLI options

### DIFF
--- a/cmd/nanodoc/error_handling_test.go
+++ b/cmd/nanodoc/error_handling_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestCLIErrorDisplay ensures that CLI errors are properly displayed to users
+// This test prevents regression of issue #66 where errors were silently swallowed
+func TestCLIErrorDisplay(t *testing.T) {
+	// Skip if not in CI or if explicitly requested
+	if os.Getenv("SKIP_INTEGRATION_TESTS") == "true" {
+		t.Skip("Skipping integration test")
+	}
+
+	// Build the binary
+	cmd := exec.Command("go", "build", "-o", "test-nanodoc", ".")
+	cmd.Dir = "."
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to build binary: %v", err)
+	}
+	defer func() { _ = os.Remove("test-nanodoc") }()
+
+	tests := []struct {
+		name           string
+		args           []string
+		wantError      string
+		wantExitCode   int
+	}{
+		{
+			name:         "invalid flag",
+			args:         []string{"--invalid-option"},
+			wantError:    "unknown flag: --invalid-option",
+			wantExitCode: 1,
+		},
+		{
+			name:         "invalid linenum value",
+			args:         []string{"--linenum", "invalid", "README.md"},
+			wantError:    "invalid --linenum value: invalid (must be 'file' or 'global')",
+			wantExitCode: 1,
+		},
+		{
+			name:         "invalid output format",
+			args:         []string{"--output-format", "wrongformat", "README.md"},
+			wantError:    "invalid --output-format value: wrongformat (must be 'term', 'plain', or 'markdown')",
+			wantExitCode: 1,
+		},
+		{
+			name:         "missing required arguments",
+			args:         []string{},
+			wantError:    "Missing paths to bundle",
+			wantExitCode: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := exec.Command("./test-nanodoc", tt.args...)
+			var stderr bytes.Buffer
+			cmd.Stderr = &stderr
+
+			err := cmd.Run()
+
+			// Check exit code
+			if exitError, ok := err.(*exec.ExitError); ok {
+				if exitError.ExitCode() != tt.wantExitCode {
+					t.Errorf("Expected exit code %d, got %d", tt.wantExitCode, exitError.ExitCode())
+				}
+			} else if tt.wantExitCode != 0 {
+				t.Errorf("Expected exit code %d, but command succeeded", tt.wantExitCode)
+			}
+
+			// Check error message
+			stderrStr := stderr.String()
+			if !strings.Contains(stderrStr, tt.wantError) {
+				t.Errorf("Expected error containing %q, got %q", tt.wantError, stderrStr)
+			}
+
+			// Ensure error is not empty when exit code is non-zero
+			if tt.wantExitCode != 0 && stderrStr == "" {
+				t.Error("Expected error message but stderr was empty")
+			}
+		})
+	}
+}

--- a/cmd/nanodoc/root.go
+++ b/cmd/nanodoc/root.go
@@ -49,7 +49,7 @@ var rootCmd = &cobra.Command{
 	Example: rootExamples,
 	Args:    cobra.ArbitraryArgs,
 	SilenceUsage: true,
-	SilenceErrors: true,
+	SilenceErrors: false,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		// Default to file completion
 		return nil, cobra.ShellCompDirectiveDefault


### PR DESCRIPTION
## Summary

This PR fixes issue #66 where nanodoc would exit with a non-zero status code but fail to display any error message when invalid CLI options were provided.

## Problem

When users provided invalid options or values, nanodoc would:
- ✅ Exit with non-zero status (correct behavior)
- ❌ Not display any error message (incorrect - users had no idea what went wrong)

## Root Cause

The issue was caused by `SilenceErrors: true` in the Cobra command configuration, which prevented error messages from being displayed to stderr.

## Solution

- Changed `SilenceErrors` from `true` to `false` in `rootCmd` configuration
- This allows Cobra to properly display error messages while maintaining the non-zero exit code

## Testing

Added comprehensive integration tests in `error_handling_test.go` that verify:
- Invalid flags display appropriate error messages
- Invalid option values show clear error descriptions
- Missing required arguments produce helpful messages
- All error cases exit with non-zero status codes

## Examples

Before this fix:
```bash
$ nanodoc --invalid-option
# (no output, just exits with code 1)

$ nanodoc --linenum invalid file.md
# (no output, just exits with code 1)
```

After this fix:
```bash
$ nanodoc --invalid-option
Error: unknown flag: --invalid-option
# (exits with code 1)

$ nanodoc --linenum invalid file.md
Error: invalid --linenum value: invalid (must be 'file' or 'global')
# (exits with code 1)
```

## Fixes

Fixes #66

## Test plan

- [x] Run new integration tests: `go test ./cmd/nanodoc -run TestCLIErrorDisplay`
- [x] Manual testing with various invalid options
- [x] Verify all existing tests still pass
- [x] Lint checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)