### PR TITLE
chore: onboard to canonical github policy + fix QF1012 lint

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @arthur-debert

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Dependabot config — see arthur-debert/release/README.md "Dependabot policy"
+#
+# Application-dependency freshness (cargo) is deliberately not enabled.
+# Major-version sweeps are evaluated as development work, not pushed by a bot.
+# Security exposure for cargo deps is covered by Dependabot security updates,
+# which are enabled per-repo via the GitHub API (not this file).
+#
+# Only github-actions freshness is enabled — old action versions silently
+# break when GitHub deprecates a runtime, so a low-volume freshness stream
+# here is worth the cost.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,15 @@
+name: Copilot Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  request:
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.fork == false
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: arthur-debert/gh-dagentic/.github/workflows/copilot-review.yml@main
+    with:
+      pr_number: ${{ github.event.pull_request.number }}

--- a/cmd/nanodoc/help.go
+++ b/cmd/nanodoc/help.go
@@ -79,11 +79,11 @@ func groupedFlagUsages(fs *pflag.FlagSet) string {
 		}
 
 		// Write group header
-		buf.WriteString(fmt.Sprintf("\033[1m%s\033[0m\n", strings.ToUpper(groupName)))
+		fmt.Fprintf(&buf, "\033[1m%s\033[0m\n", strings.ToUpper(groupName))
 
 		// Write flags in this group
 		for _, flag := range groups[groupName] {
-			buf.WriteString(fmt.Sprintf("  %s\n", flagUsage(flag)))
+			fmt.Fprintf(&buf, "  %s\n", flagUsage(flag))
 		}
 	}
 
@@ -96,14 +96,14 @@ func flagUsage(f *pflag.Flag) string {
 
 	// Build flag name part
 	if f.Shorthand != "" && f.ShorthandDeprecated == "" {
-		buf.WriteString(fmt.Sprintf("-%s, --%s", f.Shorthand, f.Name))
+		fmt.Fprintf(&buf, "-%s, --%s", f.Shorthand, f.Name)
 	} else {
-		buf.WriteString(fmt.Sprintf("    --%s", f.Name))
+		fmt.Fprintf(&buf, "    --%s", f.Name)
 	}
 
 	// Add type if not bool
 	if f.Value.Type() != "bool" {
-		buf.WriteString(fmt.Sprintf(" %s", f.Value.Type()))
+		fmt.Fprintf(&buf, " %s", f.Value.Type())
 	}
 
 	// Pad to align descriptions
@@ -119,7 +119,7 @@ func flagUsage(f *pflag.Flag) string {
 
 	// Add default value if not empty
 	if f.DefValue != "" && f.DefValue != "false" && f.DefValue != "[]" {
-		buf.WriteString(fmt.Sprintf(" (default %q)", f.DefValue))
+		fmt.Fprintf(&buf, " (default %q)", f.DefValue)
 	}
 
 	return buf.String()
@@ -134,7 +134,7 @@ func helpTopics() string {
 	}
 
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("\033[1m%s\033[0m\n", "HELP TOPICS"))
+	fmt.Fprintf(&buf, "\033[1m%s\033[0m\n", "HELP TOPICS")
 
 	// Find the longest topic name for padding
 	maxLen := 0
@@ -152,7 +152,7 @@ func helpTopics() string {
 		if !exists {
 			desc = "Documentation for " + topic
 		}
-		buf.WriteString(fmt.Sprintf("  %-*s %s\n", maxLen, topic, desc))
+		fmt.Fprintf(&buf, "  %-*s %s\n", maxLen, topic, desc)
 	}
 
 	buf.WriteString("\nRun \"nanodoc help <topic>\" for more information.")

--- a/cmd/nanodoc/root.go
+++ b/cmd/nanodoc/root.go
@@ -194,7 +194,7 @@ func saveBundleFile(path string, args []string, opts nanodoc.FormattingOptions, 
 	}
 
 	// Theme
-	content.WriteString(fmt.Sprintf("--theme=%s\n", opts.Theme))
+	fmt.Fprintf(&content, "--theme=%s\n", opts.Theme)
 
 	// File filenames
 	if !opts.ShowFilenames {
@@ -202,32 +202,32 @@ func saveBundleFile(path string, args []string, opts nanodoc.FormattingOptions, 
 	}
 
 	// File header format
-	content.WriteString(fmt.Sprintf("--header-format=%s\n", string(opts.HeaderFormat)))
-	content.WriteString(fmt.Sprintf("--header-align=%s\n", opts.HeaderAlignment))
-	content.WriteString(fmt.Sprintf("--header-style=%s\n", opts.HeaderStyle))
-	content.WriteString(fmt.Sprintf("--page-width=%d\n", opts.PageWidth))
+	fmt.Fprintf(&content, "--header-format=%s\n", string(opts.HeaderFormat))
+	fmt.Fprintf(&content, "--header-align=%s\n", opts.HeaderAlignment)
+	fmt.Fprintf(&content, "--header-style=%s\n", opts.HeaderStyle)
+	fmt.Fprintf(&content, "--page-width=%d\n", opts.PageWidth)
 
 	// File numbering
-	content.WriteString(fmt.Sprintf("--file-numbering=%s\n", string(opts.SequenceStyle)))
+	fmt.Fprintf(&content, "--file-numbering=%s\n", string(opts.SequenceStyle))
 
 	// Output format
 	if opts.OutputFormat != "" && opts.OutputFormat != "term" {
-		content.WriteString(fmt.Sprintf("--output-format=%s\n", opts.OutputFormat))
+		fmt.Fprintf(&content, "--output-format=%s\n", opts.OutputFormat)
 	}
 
 	// Additional extensions
 	for _, ext := range opts.AdditionalExtensions {
-		content.WriteString(fmt.Sprintf("--ext=%s\n", ext))
+		fmt.Fprintf(&content, "--ext=%s\n", ext)
 	}
 
 	// Include patterns
 	for _, pattern := range opts.IncludePatterns {
-		content.WriteString(fmt.Sprintf("--include=%q\n", pattern))
+		fmt.Fprintf(&content, "--include=%q\n", pattern)
 	}
 
 	// Exclude patterns
 	for _, pattern := range opts.ExcludePatterns {
-		content.WriteString(fmt.Sprintf("--exclude=%q\n", pattern))
+		fmt.Fprintf(&content, "--exclude=%q\n", pattern)
 	}
 
 	// Write content section

--- a/pkg/markdown/markdown.go
+++ b/pkg/markdown/markdown.go
@@ -183,7 +183,7 @@ func (tg *TOCGenerator) GenerateTOCMarkdown(entries []TOCEntry) string {
 	for _, entry := range entries {
 		// Create indentation based on header level
 		indent := strings.Repeat("  ", entry.Level-1)
-		builder.WriteString(fmt.Sprintf("%s- [%s](#%s)\n", indent, entry.Text, entry.ID))
+		fmt.Fprintf(&builder, "%s- [%s](#%s)\n", indent, entry.Text, entry.ID)
 	}
 	
 	return builder.String()

--- a/pkg/nanodoc/dryrun.go
+++ b/pkg/nanodoc/dryrun.go
@@ -177,7 +177,7 @@ func FormatDryRunOutput(info *DryRunInfo) string {
 	// Show TOC line count if enabled
 	if info.Options.ShowTOC {
 		tocLines := 2 + info.TotalFiles // title + separator + entries
-		output.WriteString(fmt.Sprintf("\nTable of Contents (%d lines)\n", tocLines))
+		fmt.Fprintf(&output, "\nTable of Contents (%d lines)\n", tocLines)
 	}
 	
 	// Group files by source
@@ -197,7 +197,7 @@ func FormatDryRunOutput(info *DryRunInfo) string {
 	fileNum := 1
 	for _, source := range sources {
 		files := filesBySource[source]
-		output.WriteString(fmt.Sprintf("\nFrom %s:\n", source))
+		fmt.Fprintf(&output, "\nFrom %s:\n", source)
 		
 		// Sort files within each source
 		sort.Slice(files, func(i, j int) bool {
@@ -209,7 +209,7 @@ func FormatDryRunOutput(info *DryRunInfo) string {
 			if file.RangeSpec != "" {
 				relPath = fmt.Sprintf("%s:%s", relPath, file.RangeSpec)
 			}
-			output.WriteString(fmt.Sprintf("%d. %s (%d lines)\n", fileNum, relPath, file.LineCount))
+			fmt.Fprintf(&output, "%d. %s (%d lines)\n", fileNum, relPath, file.LineCount)
 			fileNum++
 		}
 	}
@@ -218,7 +218,7 @@ func FormatDryRunOutput(info *DryRunInfo) string {
 	if len(info.Bundles) > 0 {
 		output.WriteString("\nBundle files detected:\n")
 		for _, bundle := range info.Bundles {
-			output.WriteString(fmt.Sprintf("  - %s\n", filepath.Base(bundle)))
+			fmt.Fprintf(&output, "  - %s\n", filepath.Base(bundle))
 		}
 	}
 	
@@ -226,13 +226,13 @@ func FormatDryRunOutput(info *DryRunInfo) string {
 	if len(info.RequiresExtension) > 0 {
 		output.WriteString("\nFiles requiring --ext flag:\n")
 		for file, ext := range info.RequiresExtension {
-			output.WriteString(fmt.Sprintf("  - %s (requires --ext=%s)\n", 
-				filepath.Base(file), strings.TrimPrefix(ext, ".")))
+			fmt.Fprintf(&output, "  - %s (requires --ext=%s)\n",
+				filepath.Base(file), strings.TrimPrefix(ext, "."))
 		}
 	}
 	
 	// Summary
-	output.WriteString(fmt.Sprintf("\nTotal files to process: %d (%d lines)\n", info.TotalFiles, info.TotalLines))
+	fmt.Fprintf(&output, "\nTotal files to process: %d (%d lines)\n", info.TotalFiles, info.TotalLines)
 	
 	// Show active options
 	var activeOptions []string
@@ -262,7 +262,7 @@ func FormatDryRunOutput(info *DryRunInfo) string {
 	if len(activeOptions) > 0 {
 		output.WriteString("\nOptions:\n")
 		for _, opt := range activeOptions {
-			output.WriteString(fmt.Sprintf("  %s\n", opt))
+			fmt.Fprintf(&output, "  %s\n", opt)
 		}
 	}
 	


### PR DESCRIPTION
## Summary
- Adds the stack-agnostic policy templates (CODEOWNERS, dependabot.yml, copilot-review.yml).
- Fixes 12 staticcheck QF1012 warnings (`WriteString(fmt.Sprintf(...))` → `fmt.Fprintf(&buf, ...)`) across `cmd/nanodoc/{help,root}.go`, `pkg/nanodoc/dryrun.go`, `pkg/markdown/markdown.go`. These had been blocking the local pre-commit hook.

Companion changes already applied on GitHub side:
- `main-branch-protection` ruleset
- Dependabot security alerts + automated security fixes

## Test plan
- [x] `bash scripts/lint` clean locally
- [x] `bash scripts/test` clean locally (436 tests)
- [ ] CI green