### PR TITLE
ci(copilot-review): migrate from gh-dagentic to release/@v1

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -10,6 +10,8 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: arthur-debert/gh-dagentic/.github/workflows/copilot-review.yml@main
+    uses: arthur-debert/release/.github/workflows/copilot-review.yml@v1
     with:
       pr_number: ${{ github.event.pull_request.number }}
+    secrets:
+      gh_token: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
Migrates `.github/workflows/copilot-review.yml` from `arthur-debert/gh-dagentic/.github/workflows/copilot-review.yml@main` to `arthur-debert/release/.github/workflows/copilot-review.yml@v1`.

## Why
The gh-dagentic reusable workflow authenticates with `GITHUB_TOKEN`. `GITHUB_TOKEN` authenticates as `github-actions[bot]` (Integration actor), and Integration actors **silently no-op** the Copilot review-attach. So `gh pr edit --add-reviewer @copilot` returned the PR URL with no error, but added nothing.

release/@v1 fixes this by requiring the caller to pass a user PAT (`RELEASE_TOKEN`) via `secrets.gh_token`.

## Caught by
`bin/audit-smoke-test` against arthur-debert/dodot, which opened a real PR and verified the Copilot reviewer did not actually get attached even though the workflow ran successfully. See arthur-debert/release#2.

## Auto-generated
This PR was opened by `bin/migrate-copilot-review`. Same change rolling out to all other consumers.